### PR TITLE
Fixed action stages for documentation and website build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [master, devel]
-  pull_request:
-    branches: [master, devel]
+    branches: [feature-actions]
 
 jobs:
   build:
@@ -36,7 +34,7 @@ jobs:
         if: matrix.python-version == 3.8
       - name: Build documentation
         working-directory: ./doc
-        run: sphinx-build make html
+        run: make html
         if: matrix.python-version == 3.8
       - name: Checkout gh-pages branch
         uses: actions/checkout@v2
@@ -46,13 +44,14 @@ jobs:
         if: matrix.python-version == 3.8
       - name: Update website files
         working-directory: ./gh-pages/docs
-        run: cp ${{ github.workspace }}/doc/build/html/* .
+        run: cp -r ${{ github.workspace }}/doc/build/html/* .
         if: matrix.python-version == 3.8
       - name: Commit website changes
         working-directory: ./gh-pages
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          git add docs
           git commit -a -m "Update webstite."
         if: matrix.python-version == 3.8
       - name: Push changes

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [feature-actions]
+    branches: [master, devel]
+  pull_request:
+    branches: [master, devel]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MetaWards
 
-![](https://github.com/chryswoods/MetaWards/workflows/Build.svg)
+![](https://github.com/chryswoods/MetaWards/workflows/Build/badge.svg)
 
 This is a Python port of the [MetaWards](https://github.com/ldanon/MetaWards)
 package originally written by Leon Danon. This is currently a work in progress


### PR DESCRIPTION
The documentation and website building stages are now working correctly. Sphinx is used to generate HTML files, which are copied over to the `docs` directory on the `gh-pages` branch. These are then automatically committed and pushed via an action. You'll need to setup GitHub pages to publish the project site from the `docs` directory on the `gh-pages` branch, as you did for the [BioSimSpaceWebsite](https://github.com/michellab/BioSimSpaceWebsite) repository. For now there is no `CNAME` record in the `docs` directory. This can be added if/when we choose to purchase a domain.

Core website files are in the `doc/source` directory. Look at the ones in the same location within the [BioSimSpace](https://github.com/michellab/BioSimSpace) repository to get an idea of how to write them. You'll also need to update the Python source code with NumPy style docstrings and Sphinx directives. Again, look at the BioSimSpace Python code to see how this is done. We can also add a `favicon.ico` and `logo.png` to a `doc/source/_static` directory to have them appear on the website. (I'll also need to update some Sphinx config settings.)

Cheers.